### PR TITLE
Fix lmddgtfy description typo

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -11,7 +11,7 @@ This repo is used to track the known utility bots of [devRant](https://www.devRa
 |  RandomQuote   | A bot that posts a random quote everyday                                        | Skayo       | https://devrant.com/users/RandomQuote   |
 |  translate     | A bot that can translate almost any rant to english                             | C0D4        | https://devrant.com/users/translate     |
 |  lmgtfy        | A bot that creates a lmgtfy.com url when mentioned                              | C0D4        | https://devrant.com/users/lmgtfy        |
-|  lmddgtfy      | A bot that creates a lmddgtfy.com url when mentioned                            | C0D4        | https://devrant.com/users/lmddgtfy      |
+|  lmddgtfy      | A bot that creates a lmddgtfy.net url when mentioned                            | C0D4        | https://devrant.com/users/lmddgtfy      |
 |  wiki          | A bot that returns a wikipedia url when mentioned                               | theabbie    | https://devrant.com/users/wiki          |
 |  memesbot      | A bot that posts a meme when mentioned                                          | theabbie    | https://devrant.com/users/memesbot      |
 |  here          | A bot that mentions everyone thats commented in a rant                          | pseudonim   | https://devrant.com/users/here          |

--- a/bots.csv
+++ b/bots.csv
@@ -3,7 +3,7 @@ id,name,description,profile,owner
 544294,RandomQuote,A bot that posts a random quote everyday,https://devrant.com/users/RandomQuote,Skayo
 2925487,translate,A bot that can translate almost any rant to english,https://devrant.com/users/translate,C0D4
 2483198,lmgtfy,A bot that creates a lmgtfy.com url when mentioned,https://devrant.com/users/lmgtfy,C0D4
-2485191,lmddgtfy,A bot that creates a lmddgtfy.com url when mentioned,https://devrant.com/users/lmddgtfy,C0D4
+2485191,lmddgtfy,A bot that creates a lmddgtfy.net url when mentioned,https://devrant.com/users/lmddgtfy,C0D4
 3076228,wiki,A bot that returns a wikipedia url when mentioned,https://devrant.com/users/wiki,theAbbie
 3074900,memesbot,A bot that posts a meme when mentioned,https://devrant.com/users/memesbot,theAbbie
 2179093,here,A bot that mentions everyone thats commented in a rant,https://devrant.com/users/here,pseudonim

--- a/bots.json
+++ b/bots.json
@@ -30,7 +30,7 @@
     {
         "id": 2485191,
         "name": "lmddgtfy",
-        "description": "A bot that creates a lmddgtfy.com url when mentioned",
+        "description": "A bot that creates a lmddgtfy.net url when mentioned",
         "profile": "https://devrant.com/users/lmddgtfy",
         "owner": "C0D4"
     },


### PR DESCRIPTION
Hey!
Tried going to lmddgtfy.com and it didn't work. Turns out it's lmddgtfy.net! So I fixed that